### PR TITLE
Fix that when window is small enough that controls overlapping the canvas arent clickable due to z-index

### DIFF
--- a/css/tegaki.css
+++ b/css/tegaki.css
@@ -120,6 +120,7 @@
   grid-area: 2 / 3 / 4 / 4;
   padding: 6px;
   overflow: hidden auto;
+  z-index: 1000;
 }
 
 #tegaki-status-cnt {


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/52f249a3-1973-49e0-87b2-aa8466ef833f

---

After:

https://github.com/user-attachments/assets/44a56be3-5206-4ed2-b8cd-f4d2e0c4afdd


